### PR TITLE
Fix: error about window shutting off when exception occur

### DIFF
--- a/modi_firmware_updater/core/esp32_updater.py
+++ b/modi_firmware_updater/core/esp32_updater.py
@@ -252,13 +252,11 @@ class ESP32FirmwareUpdater(serial.Serial):
         get_version_pkt = b'{"c":160,"s":25,"d":4095,"b":"AAAAAAAAAA==","l":8}'
         self.write(get_version_pkt)
         j = self.__wait_for_json()
-        print(j)
         json_msg = json.loads(j)
         init_time = time.time()
         while json_msg['c'] != 0xA1:
             self.write(get_version_pkt)
             j = self.__wait_for_json()
-            print(j)
             json_msg = json.loads(j)
             if time.time() - init_time > 1:
                 return None

--- a/modi_firmware_updater/core/esp32_updater.py
+++ b/modi_firmware_updater/core/esp32_updater.py
@@ -474,4 +474,4 @@ class ESP32FirmwareUpdater(serial.Serial):
         curr_bar = 50 * current // total
         rest_bar = 50 - curr_bar
         return f"Firmware Upload: [{'=' * curr_bar}>{'.' * rest_bar}] " \
-               f"{100 * current / total:3.2f}%"
+               f"{100 * current / total:3.1f}%"

--- a/modi_firmware_updater/core/esp32_updater.py
+++ b/modi_firmware_updater/core/esp32_updater.py
@@ -231,6 +231,7 @@ class ESP32FirmwareUpdater(serial.Serial):
             json_pkt = self.read()
             if json_pkt == b'':
                 return ''
+            time.sleep(0.1)
         json_pkt += self.read_until(b'}')
         return json_pkt
 

--- a/modi_firmware_updater/core/stm32_updater.py
+++ b/modi_firmware_updater/core/stm32_updater.py
@@ -397,7 +397,7 @@ class STM32FirmwareUpdater:
         if self.ui:
             version_path = root_path + '/' + version_file
             for line in ur.urlopen(version_path, timeout=5):
-                version_info = line.decode('utf-8').lstrip('v')
+                version_info = line.decode('utf-8').lstrip('v').rstrip('\n')
         else:
             if self.update_network_base:
                 version_file = 'base_' + version_file

--- a/modi_firmware_updater/gui_firmware_updater.py
+++ b/modi_firmware_updater/gui_firmware_updater.py
@@ -115,8 +115,8 @@ class Form(QDialog):
         QDialog.__init__(self)
         self.logger = self.__init_logger()
         self.__excepthook = sys.excepthook
-        sys.excepthook = self.__custom_excepthook
-        th.excepthook = self.__custom_thread_excepthook
+        sys.excepthook = self.__popup_excepthook
+        th.excepthook = self.__popup_thread_excepthook
 
         if installer:
             ui_path = os.path.join(
@@ -386,20 +386,20 @@ class Form(QDialog):
 
         return logger
 
-    def __custom_excepthook(self, exctype, value, traceback):
+    def __popup_excepthook(self, exctype, value, traceback):
         self.__excepthook(exctype, value, traceback)
         self.popup = PopupMessageBox(self.ui)
         self.popup.setInformativeText(str(value))
         self.popup.setDetailedText(str(tb.extract_tb(traceback)))
 
-    def __custom_thread_excepthook(self, args):
+    def __popup_thread_excepthook(self, args):
         self.stream = ThreadSignal(args)
-        self.stream.thread_error.connect(self.__signal_emit)
+        self.stream.thread_error.connect(self.__thread_error_hook)
         self.stream.run()
 
     @pyqtSlot(_th._ExceptHookArgs)
-    def __signal_emit(self, args):
-        self.__custom_excepthook(
+    def __thread_error_hook(self, args):
+        self.__popup_excepthook(
             args.exc_type, args.exc_value, args.exc_traceback
         )
 

--- a/modi_firmware_updater/gui_firmware_updater.py
+++ b/modi_firmware_updater/gui_firmware_updater.py
@@ -4,7 +4,7 @@ import time
 import logging
 import logging.handlers
 import pathlib
-
+import traceback as tb
 import threading as th
 
 from PyQt5 import uic
@@ -49,6 +49,35 @@ class StdoutRedirect(QObject):
         )
 
 
+class MyMessageBox(QtWidgets.QMessageBox):
+    def __init__(self):
+        QtWidgets.QMessageBox.__init__(self)
+        self.setSizeGripEnabled(True)
+        self.setWindowTitle('System Message')
+        self.setIcon(self.Icon.Warning)
+        self.setText('ERROR')
+        self.show()
+
+    def event(self, e):
+        result = QtWidgets.QMessageBox.event(self, e)
+
+        self.setMinimumHeight(100)
+        self.setMaximumHeight(16777215)
+        self.setMinimumWidth(200)
+        self.setMaximumWidth(16777215)
+        self.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
+
+        textEdit = self.findChild(QtWidgets.QTextEdit)
+        if textEdit != None :
+            textEdit.setMinimumHeight(100)
+            textEdit.setMaximumHeight(16777215)
+            textEdit.setMinimumWidth(500)
+            textEdit.setMaximumWidth(16777215)
+            textEdit.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
+
+        return result
+
+
 class Form(QDialog):
     """
     GUI Form of MODI Firmware Updater
@@ -59,12 +88,10 @@ class Form(QDialog):
 
         def custom_exception_hook(exctype, value, traceback):
             sys._excepthook(exctype, value, traceback)
-            self.popup = QtWidgets.QMessageBox()
-            self.popup.setIcon(self.popup.Icon.Warning)
-            self.popup.setText('Warning')
+            self.popup = MyMessageBox()
             self.popup.setInformativeText(str(value))
+            self.popup.setDetailedText(str(tb.extract_tb(traceback)))
             self.popup.buttonClicked.connect(self.popup_btn)
-            self.popup.show()
 
         sys._excepthook = sys.excepthook
         sys.excepthook = custom_exception_hook

--- a/modi_firmware_updater/gui_firmware_updater.py
+++ b/modi_firmware_updater/gui_firmware_updater.py
@@ -83,7 +83,8 @@ class PopupMessageBox(QtWidgets.QMessageBox):
             textEdit.setMinimumWidth(500)
             textEdit.setMaximumWidth(16777215)
             textEdit.setSizePolicy(
-                QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding
+                QtWidgets.QSizePolicy.Expanding,
+                QtWidgets.QSizePolicy.Expanding
             )
 
         return result

--- a/modi_firmware_updater/gui_firmware_updater.py
+++ b/modi_firmware_updater/gui_firmware_updater.py
@@ -57,16 +57,17 @@ class Form(QDialog):
     def __init__(self, installer=False):
         self.logger = self.__init_logger()
 
-        def my_exception_hook(exctype, value, traceback):
-            print(exctype, value, traceback)
-            self.popup = QtWidgets.QMessageBox()
-            self.popup.setText('Close')
-            self.popup.buttonClicked.connect(self.btn)
-            self.popup.show()
+        def custom_exception_hook(exctype, value, traceback):
             sys._excepthook(exctype, value, traceback)
+            self.popup = QtWidgets.QMessageBox()
+            self.popup.setIcon(self.popup.Icon.Warning)
+            self.popup.setText('Warning')
+            self.popup.setInformativeText(str(value))
+            self.popup.buttonClicked.connect(self.popup_btn)
+            self.popup.show()
 
         sys._excepthook = sys.excepthook
-        sys.excepthook = my_exception_hook
+        sys.excepthook = custom_exception_hook
 
         QDialog.__init__(self)
         if installer:
@@ -320,7 +321,7 @@ class Form(QDialog):
         for i, button in enumerate(self.buttons):
             button.setText(appropriate_translation[i])
 
-    def btn(self):
+    def popup_btn(self):
         self.ui.close()
 
     #

--- a/modi_firmware_updater/gui_firmware_updater.py
+++ b/modi_firmware_updater/gui_firmware_updater.py
@@ -56,6 +56,14 @@ class Form(QDialog):
 
     def __init__(self, installer=False):
         self.logger = self.__init_logger()
+
+        def my_exception_hook(exctype, value, traceback):
+            print(exctype, value, traceback)
+            sys._excepthook(exctype, value, traceback)
+
+        sys._excepthook = sys.excepthook
+        sys.excepthook = my_exception_hook
+
         QDialog.__init__(self)
         if installer:
             ui_path = os.path.join(
@@ -323,17 +331,6 @@ class Form(QDialog):
         file_handler.setLevel(logging.DEBUG)
         file_handler.setFormatter(formatter)
 
-        # smtp_handler = logging.handlers.SMTPHandler(
-        #     mailhost='mailserver',
-        #     fromaddr='canddang95@naver.com',
-        #     toaddrs='yjm9507@yonsei.ac.kr',
-        #     subject='GUI MODI Firmware Updater Log',
-        # )
-        # smtp_handler.setLevel(logging.DEBUG)
-        # smtp_handler.setFormatter(formatter)
-
-        # logger.addHandler(file_handler)
-        # logger.addHandler(smtp_handler)
         return logger
 
     def __click_motion(self, button_type, start_time):

--- a/modi_firmware_updater/gui_firmware_updater.py
+++ b/modi_firmware_updater/gui_firmware_updater.py
@@ -59,6 +59,10 @@ class Form(QDialog):
 
         def my_exception_hook(exctype, value, traceback):
             print(exctype, value, traceback)
+            self.popup = QtWidgets.QMessageBox()
+            self.popup.setText('Close')
+            self.popup.buttonClicked.connect(self.btn)
+            self.popup.show()
             sys._excepthook(exctype, value, traceback)
 
         sys._excepthook = sys.excepthook
@@ -315,6 +319,9 @@ class Form(QDialog):
         self.ui.is_english = not self.ui.is_english
         for i, button in enumerate(self.buttons):
             button.setText(appropriate_translation[i])
+
+    def btn(self):
+        self.ui.close()
 
     #
     # Helper functions


### PR DESCRIPTION
### 작업 개요
1 메인 스레드에서 예외가 발생해 정지 상태에서 버튼을 다시 누르면 창이 꺼지는 현상.
2 메인 스레드 안의 스레드에서 업데이트가 진행 중 예외가 발생 시 창이 바로 꺼지는 현상.
위 두가지 에러를 해결하기 위해 예외 발생 시 팝업창을 띄워주도록 작업 진행.

### Jira
해당 사항 없음

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
  1. sys.excepthook, threading.excepthook를 재정의해 예외 발생 상황의 event를 catch해 팝업을 띄워줌.
  2. 팝업 창에 Exit, Report error, Show details 버튼 생성: 각각 창 닫기, 에러 로그 메일 전송, 에러 내용 확인 기능.
    (TODO: Report error 에러 로그 메일 전송)
  3. ESP json 통신 시 패킷들이 간섭되어 delimeter 에러가 발생하는 것을 방지하기 위해 sleep(0.1) 추가.
  4. Progress bar의 소숫점 1자리로 변경, version info 뒤의 개행(\n) 삭제 등의 사소한 변경.

### 생각해볼 문제
  1. 예외 상황을 excepthook으로 catch해주고 있는데, 이를 더 개선하는 방법.
  2. Report error버튼을 눌렀을 때 이때까지 저장된 로그를 메일로 전송하는 방법.